### PR TITLE
Replace kapt with KSP. https://developer.android.com/build/migrate-to-ksp

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,6 +1,3 @@
-* Use KSP not kapt for room.
-  - https://developer.android.com/build/migrate-to-ksp
-
 * NDK crash reporting
 
 * Splashscreen has very large image on android-21 emulator.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'com.android.application'
     id 'com.google.android.gms.oss-licenses-plugin'
     id 'kotlin-android'
-    id 'org.jetbrains.kotlin.kapt'
+    id 'com.google.devtools.ksp'
     id 'com.google.gms.google-services'
     id 'com.google.firebase.crashlytics'
 }
@@ -115,7 +115,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-mlkit-face-detection:16.1.4'
     implementation 'com.google.android.gms:play-services-oss-licenses:17.0.0'
     implementation 'com.google.android.material:material:1.10.0'
-    kapt "androidx.room:room-compiler:${room_version}"
+    ksp "androidx.room:room-compiler:${room_version}"
     testImplementation "androidx.arch.core:core-testing:2.1.0"
     testImplementation "androidx.room:room-testing:${room_version}"
     testImplementation 'junit:junit:4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,10 @@ buildscript {
     }
 }
 
+plugins {
+    id 'com.google.devtools.ksp' version "${kotlin_version}-1.0.15" apply false
+}
+
 allprojects {
     repositories {
         google()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 android.useAndroidX=true
-android.enableJetifier=true
+android.enableJetifier=false
 kotlin.code.style=official
 RELEASE_STORE_FILE=../../merging-secrets/release.keystore
 RELEASE_STORE_PASSWORD_FILE=../../merging-secrets/release.password


### PR DESCRIPTION
* https://developer.android.com/build/migrate-to-ksp
* jetifier and KSP parts of this PR are independent of each other (as far as I know, although didn't test this directly).