### PR TITLE
Make publishing work again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,9 +39,15 @@ jobs:
       - run:
           name: gradle assembleProduct
           command: ./gradlew assembleProduct
+      - run:
+          name: gradle bundleProductRelease
+          command: ./gradlew bundleProductRelease
       - store_artifacts: # https://circleci.com/docs/2.0/artifacts/
           path: app/build/outputs/apk/product/release/app-product-release.apk
           destination: apks/app-product-release.apk
+      - store_artifacts:
+          path: app/build/outputs/bundle/productRelease/app-product-release.aab
+          destination: aabs/app-product-release.aab
       - store_artifacts:
           path: app/build/reports
           destination: reports
@@ -83,9 +89,9 @@ jobs:
           name: Create google-play-service.json
           command: printf "%s" "${GOOGLE_PLAY_SERVICE_JSON}" | base64 --decode > google-play-service.json
       - run:
-          name: "Publish Release to Google Play Store"
+          name: "Publish to Google Play Store"
           command: |
-            bin/fastlane supply --track beta --apk ./artifacts/outputs/apk/product/release/app-product-release.apk
+            bin/fastlane supply --track internal --aab ./app/build/outputs/bundle/productRelease/app-product-release.aab
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,7 @@ jobs:
       - run:
           name: "Publish to Google Play Store"
           command: |
+            ls -al ./app/build/outputs
             bin/fastlane supply --track internal --aab ./app/build/outputs/bundle/productRelease/app-product-release.aab
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,14 +17,12 @@ jobs:
       - run:
           name: Create google-services.json (product flavour)
           command: |
-            mkdir -p app/src/product
-            test -d app/src/product
-            ls -l app/src/product/google-services.json
+            rm app/src/product/google-services.json # symlink, for local builds
             printf "%s" "${GOOGLE_SERVICES}" | base64 --decode > app/src/product/google-services.json
       - run:
           name: Create google-services.json (develop flavour)
           command: |
-            mkdir -p app/src/develop
+            rm app/src/develop/google-services.json # symlink, for local builds
             printf "%s" "${GOOGLE_SERVICES_DEVELOP}" | base64 --decode > app/src/develop/google-services.json
       - run:
           name: Create release.password

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,9 +68,6 @@ jobs:
       - image: cimg/ruby:3.2.2
     steps:
       - checkout
-      - run:
-          command: |
-            env | sort
       - restore_cache:
           key: rbenv-{{ checksum "Gemfile.lock" }}-{{ checksum "Gemfile" }}-{{ checksum ".ruby-version" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,14 @@ jobs:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
       - run:
           name: Create google-services.json (product flavour)
-          command: mkdir -p app/src/product && printf "%s" "${GOOGLE_SERVICES}" | base64 --decode > app/src/product/google-services.json
+          command: |
+            mkdir -p app/src/product
+            printf "%s" "${GOOGLE_SERVICES}" | base64 --decode > app/src/product/google-services.json
       - run:
           name: Create google-services.json (develop flavour)
-          command: mkdir -p app/src/develop && printf "%s" "${GOOGLE_SERVICES_DEVELOP}" | base64 --decode > app/src/develop/google-services.json
+          command: |
+            mkdir -p app/src/develop
+            printf "%s" "${GOOGLE_SERVICES_DEVELOP}" | base64 --decode > app/src/develop/google-services.json
       - run:
           name: Create release.password
           command: printf "%s\n" "${RELEASE_KEY_PASSWORD:-}" > "${ORG_GRADLE_PROJECT_RELEASE_KEY_PASSWORD_FILE}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
       - run:
           name: "Publish Release on GitHub"
           command: |
-            VERSION=$(cat ./artifacts/version)
+            VERSION=$(cat ./app/build/version)
             ghr -t "${GITHUB_TOKEN}"  -u "${CIRCLE_PROJECT_USERNAME}" -r "${CIRCLE_PROJECT_REPONAME}" -c "${CIRCLE_SHA1}" "v${VERSION}" ./app/build/outputs/apk/product/release/app-product-release.apk
   publish-play-store:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
       - run:
           name: Create google-services.json (product flavour)
-          command: printf "%s" "${GOOGLE_SERVICES}" | base64 --decode > app/src/product/google-services.json
+          command: pwd && ls -l && printf "%s" "${GOOGLE_SERVICES}" | base64 --decode > app/src/product/google-services.json
       - run:
           name: Create google-services.json (develop flavour)
           command: printf "%s" "${GOOGLE_SERVICES_DEVELOP}" | base64 --decode > app/src/develop/google-services.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,8 @@ jobs:
           name: Create google-services.json (product flavour)
           command: |
             mkdir -p app/src/product
+            test -d app/src/product
+            ls -l app/src/product/google-services.json
             printf "%s" "${GOOGLE_SERVICES}" | base64 --decode > app/src/product/google-services.json
       - run:
           name: Create google-services.json (develop flavour)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,13 +101,13 @@ workflows:
       - publish-github-release:
           requires:
             - build
-          filters:
-            branches:
-              only: release
+#          filters:
+#            branches:
+#              only: release
       - publish-play-store:
           requires:
             - build
-          filters:
-            branches:
-              only: release
+#          filters:
+#            branches:
+#              only: release
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,10 @@ jobs:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
       - run:
           name: Create google-services.json (product flavour)
-          command: rm -f app/src/product/google-services.json && printf "%s" "${GOOGLE_SERVICES}" | base64 --decode > app/src/product/google-services.json
+          command: printf "%s" "${GOOGLE_SERVICES}" | base64 --decode > app/src/product/google-services.json
       - run:
           name: Create google-services.json (develop flavour)
-          command: rm -f app/src/develop/google-services.json && printf "%s" "${GOOGLE_SERVICES_DEVELOP}" | base64 --decode > app/src/develop/google-services.json
+          command: printf "%s" "${GOOGLE_SERVICES_DEVELOP}" | base64 --decode > app/src/develop/google-services.json
       - run:
           name: Create release.password
           command: printf "%s\n" "${RELEASE_KEY_PASSWORD:-}" > "${ORG_GRADLE_PROJECT_RELEASE_KEY_PASSWORD_FILE}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,10 @@ jobs:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
       - run:
           name: Create google-services.json (product flavour)
-          command: pwd && ls -l && printf "%s" "${GOOGLE_SERVICES}" | base64 --decode > app/src/product/google-services.json
+          command: mkdir -p app/src/product && printf "%s" "${GOOGLE_SERVICES}" | base64 --decode > app/src/product/google-services.json
       - run:
           name: Create google-services.json (develop flavour)
-          command: printf "%s" "${GOOGLE_SERVICES_DEVELOP}" | base64 --decode > app/src/develop/google-services.json
+          command: mkdir -p app/src/develop && printf "%s" "${GOOGLE_SERVICES_DEVELOP}" | base64 --decode > app/src/develop/google-services.json
       - run:
           name: Create release.password
           command: printf "%s\n" "${RELEASE_KEY_PASSWORD:-}" > "${ORG_GRADLE_PROJECT_RELEASE_KEY_PASSWORD_FILE}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,12 +67,12 @@ jobs:
       - image: cibuilds/github:0.13
     steps:
       - attach_workspace:
-          at: ./artifacts
+          at: ./app/build
       - run:
           name: "Publish Release on GitHub"
           command: |
             VERSION=$(cat ./artifacts/version)
-            ghr -t "${GITHUB_TOKEN}"  -u "${CIRCLE_PROJECT_USERNAME}" -r "${CIRCLE_PROJECT_REPONAME}" -c "${CIRCLE_SHA1}" "v${VERSION}" ./artifacts/outputs/apk/product/release/app-product-release.apk
+            ghr -t "${GITHUB_TOKEN}"  -u "${CIRCLE_PROJECT_USERNAME}" -r "${CIRCLE_PROJECT_REPONAME}" -c "${CIRCLE_SHA1}" "v${VERSION}" ./app/build/outputs/apk/product/release/app-product-release.apk
   publish-play-store:
     docker:
       - image: cimg/ruby:3.2.2
@@ -88,14 +88,13 @@ jobs:
             - ~/.rbenv
           key: rbenv-{{ checksum "Gemfile.lock" }}-{{ checksum "Gemfile" }}-{{ checksum ".ruby-version" }}
       - attach_workspace:
-          at: ./artifacts
+          at: ./app/build
       - run:
           name: Create google-play-service.json
           command: printf "%s" "${GOOGLE_PLAY_SERVICE_JSON}" | base64 --decode > google-play-service.json
       - run:
           name: "Publish to Google Play Store"
           command: |
-            ls -al ./app/build/outputs
             bin/fastlane supply --track internal --aab ./app/build/outputs/bundle/productRelease/app-product-release.aab
 
 workflows:

--- a/TODO
+++ b/TODO
@@ -5,20 +5,21 @@
   X AppFile
   X new google play account
   X verify google play account
-  - get new google-play-service.json
-  - firebase
+  X get new google-play-service.json
+  X firebase
     X add new app id to existing configs
       X keeping old app id so still get analytics from any users
-    - update local google-services.json
+    X update local google-services.json
       X develop
       X product
-    - update circle CI config
-       X not worth renaming secrets env. vars. to keep support for old branches
-         X which need config with old app id.
-       - google-services.json
-         - develop
-         - product
-       - google-play-service.json
+  X update circle CI config
+     X not worth renaming secrets env. vars. to keep support for old branches
+       X which need config with old app id.
+     X google-services.json
+       X develop
+       X product
+     X google-play-service.json
+  - can't use open testing any more, so move to internal testing
 
 * Try out JetPack compose.
   - add detekt plugin.

--- a/TODO
+++ b/TODO
@@ -20,6 +20,7 @@
        X product
      X google-play-service.json
   - can't use open testing any more, so move to internal testing
+  - build aab not apk
 
 * Try out JetPack compose.
   - add detekt plugin.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,7 +68,7 @@ android {
     }
     buildTypes {
         release {
-            if (releaseStoreFile.exists() && releaseStoreFile.size() > 0) {
+            if (releaseStoreFile.exists()) {
                 signingConfig signingConfigs.release
             }
             minifyEnabled false

--- a/fastlane/metadata/android/en-GB/changelogs/203.txt
+++ b/fastlane/metadata/android/en-GB/changelogs/203.txt
@@ -1,0 +1,1 @@
+Publish using aab.


### PR DESCRIPTION
* New apps need to use aab not apk to upload to play store.
* Can't use beta track any more for new apps (unless get 20 people to test for two weeks). Use internal instead.
* Misc. tidying.