### PR TITLE
Revert release-job debugging.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,13 +105,13 @@ workflows:
       - publish-github-release:
           requires:
             - build
-#          filters:
-#            branches:
-#              only: release
+          filters:
+            branches:
+              only: release
       - publish-play-store:
           requires:
             - build
-#          filters:
-#            branches:
-#              only: release
+          filters:
+            branches:
+              only: release
 


### PR DESCRIPTION
Previous PR shouldn't have enabled release jobs on all branches.