### PR TITLE
targetSdkVersion 36

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/code
     docker:
-      - image: cimg/android:2023.11.1
+      - image: cimg/android:2025.08.1
     resource_class: large
     environment:
       JVM_OPTS: -Xmx3200m

--- a/.idea/AndroidProjectSystem.xml
+++ b/.idea/AndroidProjectSystem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidProjectSystem">
+    <option name="providerId" value="com.android.tools.idea.GradleProjectSystem" />
+  </component>
+</project>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17" />
+    <bytecodeTargetLevel target="21" />
   </component>
 </project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetSelector">
+    <selectionStates>
+      <SelectionState runConfigName="app">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+    </selectionStates>
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,15 +4,15 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
+        <option name="gradleJvm" value="#JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.intellij.execution.junit.AbstractAllInDirectoryConfigurationProducer" />
+        <option value="com.intellij.execution.junit.AllInPackageConfigurationProducer" />
+        <option value="com.intellij.execution.junit.PatternConfigurationProducer" />
+        <option value="com.intellij.execution.junit.TestInClassConfigurationProducer" />
+        <option value="com.intellij.execution.junit.UniqueIdConfigurationProducer" />
+        <option value="com.intellij.execution.junit.testDiscovery.JUnitTestDiscoveryConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinJUnitRunConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinPatternConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/.idea/studiobot.xml
+++ b/.idea/studiobot.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="StudioBotProjectSettings">
+    <option name="shareContext" value="OptedIn" />
+  </component>
+</project>

--- a/TODO
+++ b/TODO
@@ -1,5 +1,10 @@
+* Make new release.
+
 * Fix libraries with non-16K alignment
   - before 1st Nov 2025
+  - lib/arm64-v8a/libimagepipeline.so
+  - lib/arm64-v8a/libnative-filters.so
+  - lib/arm64-v8a/libnative-imagetranscoder.so
 
 * Release with new app id
   X build.gradle

--- a/TODO
+++ b/TODO
@@ -1,5 +1,7 @@
 * Make new release.
 
+* targetSdkVersion 34 -> 36 has pushed the app's action bars into the phone's status bar
+
 * Fix libraries with non-16K alignment
   - before 1st Nov 2025
   - lib/arm64-v8a/libimagepipeline.so

--- a/TODO
+++ b/TODO
@@ -1,3 +1,6 @@
+* Fix libraries with non-16K alignment
+  - before 1st Nov 2025
+
 * Release with new app id
   X build.gradle
   X rename classes

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,7 +49,7 @@ android {
     defaultConfig {
         applicationId "uk.me.jeremygreen.merging2"
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion 36
         versionCode findVersionCode()
         versionName findVersionName()
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,7 +45,7 @@ static String findVersionName() {
 def releaseStoreFile = file(RELEASE_STORE_FILE, PathValidation.NONE)
 
 android {
-    compileSdk 34
+    compileSdk 36
     defaultConfig {
         applicationId "uk.me.jeremygreen.merging2"
         minSdkVersion 21

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -127,8 +127,8 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-rules-libraries:1.23.6")
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-rules-ruleauthors:1.23.6")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-rules-libraries:1.23.8")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-rules-ruleauthors:1.23.8")
 }
 
 task writeVersionFile {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,8 +76,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
     flavorDimensions "flavour"
     productFlavors {

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         classpath 'com.google.android.gms:oss-licenses-plugin:0.10.6'
         classpath 'com.google.gms:google-services:4.4.0'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.8.1'
-        classpath 'io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.3'
+        classpath 'io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.8'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.0'
+        classpath 'com.android.tools.build:gradle:8.12.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.android.gms:oss-licenses-plugin:0.10.6'
         classpath 'com.google.gms:google-services:4.4.0'

--- a/environment
+++ b/environment
@@ -5,7 +5,7 @@
 SOURCE_DIR="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")"
 
 # java
-export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
 export PATH="${JAVA_HOME}/bin:${PATH}"
 
 # ruby

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Dec 01 17:10:32 GMT 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR changes targetSdkVersion from 34 to 36, since will soon need this to be able to upload app to store:

> Starting August 31 2025:
> 
> * New apps and app updates must target Android 15 (API level 35) or higher to be submitted to Google Play; except for Wear OS, Android Automotive OS, and Android TV apps, which must target Android 14 (API level 34) or higher.
> * Existing apps must target Android 14 (API level 34) or higher to remain available to new users on devices running Android OS higher than your app's target API level. Apps that target Android 13 (API level 33) or lower, including Android 12 (API level 31) or lower for Wear OS and Android TV, will only be available on devices running Android OS that are the same or lower than your app's target API level.

This affects the following things:

https://developer.android.com/about/versions/15/behavior-changes-15
https://developer.android.com/about/versions/16/behavior-changes-16

Haven't accounted for https://developer.android.com/about/versions/15/behavior-changes-15#edge-to-edge, so app tool bar is now rendered under the phone status bar. Will fix this as part of the [PR](https://github.com/jg210/merging/pull/42) that will move to JetPack Compose.

Also had to upgrade some other things:

* Circle CI image, to add new SDK support
* Java, since CI image has java 21.
* compileSdkVersion, since needs to be >= targetSdkVersion to make gradlew checks pass.
* detekt plugin, since didn't work with java 21.
* AGP plugin, to support new targetSdkVersion properly.
* gradle, to match AGP plugin.