### PR TITLE
End-to-end tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,13 @@
 version: 2
+
+executors:
+  android_executor: &android_executor
+    docker:
+      - image: cimg/android:2025.08.1
+    resource_class: large
+    environment:
+      JVM_OPTS: -Xmx3200m
+
 commands:
   cache_gradle_dependencies:
     steps:
@@ -22,11 +31,8 @@ commands:
 jobs:
   build:
     working_directory: ~/code
-    docker:
-      - image: cimg/android:2025.08.1
-    resource_class: large
+    <<: *android_executor
     environment:
-      JVM_OPTS: -Xmx3200m
       ORG_GRADLE_PROJECT_RELEASE_STORE_FILE: /home/circleci/code/release.keystore
       ORG_GRADLE_PROJECT_RELEASE_STORE_PASSWORD_FILE: /home/circleci/code/release.password
       ORG_GRADLE_PROJECT_RELEASE_KEY_PASSWORD_FILE: /home/circleci/code/release.password

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ jobs:
             adb shell settings put global animator_duration_scale 0.0
       - run:
           name: androidTest
-          command: ./gradlew connectedProductDebugAndroidTest
+          command: ./gradlew connectedProductDebugAndroidTest --scan
       - store_artifacts:
           path: app/build/reports
           destination: reports/app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,8 @@ jobs:
   androidTest:
     working_directory: ~/code
     machine:
-      image: android
+      image: android:default
+    resource_class: large
     environment:
       JVM_OPTS: -Xmx3200m
       ORG_GRADLE_PROJECT_RELEASE_STORE_FILE: /home/circleci/code/release.keystore

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,11 +87,11 @@ jobs:
           at: ./app/build
       - cache_gradle_dependencies
       - run:
-        name: Create avd
-        command: |
-          SYSTEM_IMAGE="system-images;android-36;google_apis;x86_64"
-          sdkmanager "${SYSTEM_IMAGE}"
-          echo "no" | avdmanager --verbose create avd -n test -k "${SYSTEM_IMAGES}"
+          name: Create avd
+          command: |
+            SYSTEM_IMAGE="system-images;android-36;google_apis;x86_64"
+            sdkmanager "${SYSTEM_IMAGE}"
+            echo "no" | avdmanager --verbose create avd -n test -k "${SYSTEM_IMAGES}"
       - run:
           name: Launch emulator
           command: |
@@ -110,7 +110,6 @@ jobs:
       - run:
           name: androidTest
           command: ./gradlew connectedDebugAndroidTest
-
   publish-github-release:
     docker:
       - image: cibuilds/github:0.13

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,7 @@ jobs:
       ORG_GRADLE_PROJECT_RELEASE_STORE_FILE: /home/circleci/code/release.keystore
       ORG_GRADLE_PROJECT_RELEASE_STORE_PASSWORD_FILE: /home/circleci/code/release.password
       ORG_GRADLE_PROJECT_RELEASE_KEY_PASSWORD_FILE: /home/circleci/code/release.password
+      SYSTEM_IMAGE: system-images;<< parameters.system_image >>
     steps:
       - checkout
       - attach_workspace:
@@ -99,8 +100,8 @@ jobs:
       - run:
           name: Create avd
           command: |
-            sdkmanager "system-images;"<< parameters.system_image >>
-            echo "no" | avdmanager --verbose create avd -n test -k "system-images;"<< parameters.system_image >>
+            sdkmanager "${SYSTEM_IMAGE}"
+            echo "no" | avdmanager --verbose create avd -n test -k "${SYSTEM_IMAGE}"
       - run:
           name: Launch emulator
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,9 @@ _cache_keys:
   build_gradle_deps_full:  &build_gradle_deps_full  "build-gradle-deps-v1-{{ checksum \"build.gradle\" }}-{{ checksum \"app/build.gradle\" }}-{{ checksum \"gradle.properties\" }}-{{ checksum \"gradle/wrapper/gradle-wrapper.properties\" }}-{{ checksum \"settings.gradle\" }}-{{ checksum \"dependencies.gradle\" }}"
   build_gradle_deps_short: &build_gradle_deps_short "build-gradle-deps-v1-{{ checksum \"build.gradle\" }}-{{ checksum \"app/build.gradle\" }}-{{ checksum \"gradle.properties\" }}"
   build_gradle_deps_base:  &build_gradle_deps_base  "build-gradle-deps-v1-"
-  build_android_sdk_full:  &build_android_sdk_full  "build-android-sdk-v1-{{ checksum \"build.gradle\" }}-{{ checksum \"app/build.gradle\" }}-{{ checksum \"gradle.properties\" }}"
-  build_android_sdk_base:  &build_android_sdk_base  "build-android-sdk-v1-"
   androidTest_gradle_deps_full:  &androidTest_gradle_deps_full  "androidTest-gradle-deps-v1-{{ checksum \"build.gradle\" }}-{{ checksum \"app/build.gradle\" }}-{{ checksum \"gradle.properties\" }}-{{ checksum \"gradle/wrapper/gradle-wrapper.properties\" }}-{{ checksum \"settings.gradle\" }}-{{ checksum \"dependencies.gradle\" }}"
   androidTest_gradle_deps_short: &androidTest_gradle_deps_short "androidTest-gradle-deps-v1-{{ checksum \"build.gradle\" }}-{{ checksum \"app/build.gradle\" }}-{{ checksum \"gradle.properties\" }}"
   androidTest_gradle_deps_base:  &androidTest_gradle_deps_base  "androidTest-gradle-deps-v1-"
-  androidTest_android_sdk_full:  &androidTest_android_sdk_full  "androidTest-android-sdk-v1-{{ checksum \"build.gradle\" }}-{{ checksum \"app/build.gradle\" }}-{{ checksum \"gradle.properties\" }}"
-  androidTest_android_sdk_base:  &androidTest_android_sdk_base  "androidTest-android-sdk-v1-"
 
 executors:
   android_executor:
@@ -47,11 +43,6 @@ jobs:
             - *build_gradle_deps_full
             - *build_gradle_deps_short
             - *build_gradle_deps_base
-      - restore_cache:
-          name: Restoring cache - Android SDK
-          keys:
-            - *build_android_sdk_full
-            - *build_android_sdk_base
       - run:
           name: Create google-services.json (develop flavour)
           command: |
@@ -108,11 +99,6 @@ jobs:
           paths:
             - ~/.gradle
           key: *build_gradle_deps_full
-      - save_cache:
-          name: Saving cache - Android SDK
-          paths:
-            - ~/android-sdk
-          key: *build_android_sdk_full
 
   androidTest:
     parameters:
@@ -139,13 +125,6 @@ jobs:
             - *build_gradle_deps_full
             - *build_gradle_deps_short
             - *build_gradle_deps_base
-      - restore_cache:
-          name: Restoring cache - Android SDK
-          keys:
-            - *androidTest_android_sdk_full
-            - *androidTest_android_sdk_base
-            - *build_android_sdk_full
-            - *build_android_sdk_base
       - run:
           name: Remove old reports
           command: rm -fR build/reports app/build/reports
@@ -184,11 +163,6 @@ jobs:
           paths:
             - ~/.gradle
           key: androidTest-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
-      - save_cache:
-          name: Saving cache - Android SDK
-          paths:
-            - ~/android-sdk
-          key: androidTest-android-sdk-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
 
   publish-github-release:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,8 +99,8 @@ jobs:
       - run:
           name: Create avd
           command: |
-            sdkmanager << parameters.system_image >>
-            echo "no" | avdmanager --verbose create avd -n test -k << parameters.system_image >>
+            sdkmanager system-images;<< parameters.system_image >>
+            echo "no" | avdmanager --verbose create avd -n test -k system-images;<< parameters.system_image >>
       - run:
           name: Launch emulator
           command: |
@@ -172,8 +172,8 @@ workflows:
           matrix:
             parameters:
               system_image:
-                - system-images;android-36;google_apis;x86_64
-                - system-images;android-23;google_apis;x86_64
+                - android-36;google_apis;x86_64
+                - android-23;google_apis;x86_64
       - publish-github-release:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 executors:
   android_executor: &android_executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 executors:
-  android_executor: &android_executor
+  android_executor:
     docker:
       - image: cimg/android:2025.08.1
     resource_class: large
@@ -31,7 +31,7 @@ commands:
 jobs:
   build:
     working_directory: ~/code
-    <<: *android_executor
+    executor: android_executor
     environment:
       ORG_GRADLE_PROJECT_RELEASE_STORE_FILE: /home/circleci/code/release.keystore
       ORG_GRADLE_PROJECT_RELEASE_STORE_PASSWORD_FILE: /home/circleci/code/release.password

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,9 +78,6 @@ jobs:
           paths:
             - build
   androidTest:
-    parameters:
-      system_image:
-        type: string
     working_directory: ~/code
     machine:
       image: android:default
@@ -99,8 +96,9 @@ jobs:
       - run:
           name: Create avd
           command: |
-            sdkmanager system-images;<< parameters.system_image >>
-            echo "no" | avdmanager --verbose create avd -n test -k system-images;<< parameters.system_image >>
+            SYSTEM_IMAGE="system-images;android-36;google_apis;x86_64"
+            sdkmanager "${SYSTEM_IMAGE}"
+            echo "no" | avdmanager --verbose create avd -n test -k "${SYSTEM_IMAGE}"
       - run:
           name: Launch emulator
           command: |
@@ -169,11 +167,6 @@ workflows:
       - androidTest:
           requires:
             - build
-          matrix:
-            parameters:
-              system_image:
-                - android-36;google_apis;x86_64
-                - android-23;google_apis;x86_64
       - publish-github-release:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,14 @@ jobs:
             - outputs
   androidTest:
     working_directory: ~/code
-    executor: android_executor
+    machine:
+      image: android
+    resource_class: large
+    environment:
+      JVM_OPTS: -Xmx3200m
+      ORG_GRADLE_PROJECT_RELEASE_STORE_FILE: /home/circleci/code/release.keystore
+      ORG_GRADLE_PROJECT_RELEASE_STORE_PASSWORD_FILE: /home/circleci/code/release.password
+      ORG_GRADLE_PROJECT_RELEASE_KEY_PASSWORD_FILE: /home/circleci/code/release.password
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,6 @@ jobs:
     working_directory: ~/code
     machine:
       image: android
-    resource_class: large
     environment:
       JVM_OPTS: -Xmx3200m
       ORG_GRADLE_PROJECT_RELEASE_STORE_FILE: /home/circleci/code/release.keystore

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,10 +70,10 @@ jobs:
           destination: aabs/app-product-release.aab
       - store_artifacts:
           path: app/build/reports
-          destination: reports/build/app
+          destination: reports/app
       - store_artifacts:
           path: build/reports
-          destination: reports/build/project
+          destination: reports/project
       - store_test_results: # https://circleci.com/docs/2.0/collect-test-data/
           path: app/build/test-results
       - persist_to_workspace:
@@ -127,10 +127,10 @@ jobs:
           command: ./gradlew connectedProductDebugAndroidTest
       - store_artifacts:
           path: app/build/reports
-          destination: reports/androidTest/<< parameters.system_image >>/app
+          destination: reports/app
       - store_artifacts:
           path: build/reports
-          destination: reports/androidTest/<< parameters.system_image >>/project
+          destination: reports/project
       - store_test_results: # https://circleci.com/docs/2.0/collect-test-data/
           path: app/build/outputs/androidTest-results/connected/debug/flavors/product/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,18 @@ _shared_env_vars: &shared_env_vars
   ORG_GRADLE_PROJECT_RELEASE_STORE_PASSWORD_FILE: /home/circleci/code/release.password
   ORG_GRADLE_PROJECT_RELEASE_KEY_PASSWORD_FILE: /home/circleci/code/release.password
 
+_cache_keys:
+  build_gradle_deps_full:  &build_gradle_deps_full  "build-gradle-deps-v1-{{ checksum \"build.gradle\" }}-{{ checksum \"app/build.gradle\" }}-{{ checksum \"gradle.properties\" }}-{{ checksum \"gradle/wrapper/gradle-wrapper.properties\" }}-{{ checksum \"settings.gradle\" }}-{{ checksum \"dependencies.gradle\" }}"
+  build_gradle_deps_short: &build_gradle_deps_short "build-gradle-deps-v1-{{ checksum \"build.gradle\" }}-{{ checksum \"app/build.gradle\" }}-{{ checksum \"gradle.properties\" }}"
+  build_gradle_deps_base:  &build_gradle_deps_base  "build-gradle-deps-v1-"
+  build_android_sdk_full:  &build_android_sdk_full  "build-android-sdk-v1-{{ checksum \"build.gradle\" }}-{{ checksum \"app/build.gradle\" }}-{{ checksum \"gradle.properties\" }}"
+  build_android_sdk_base:  &build_android_sdk_base  "build-android-sdk-v1-"
+  androidTest_gradle_deps_full:  &androidTest_gradle_deps_full  "androidTest-gradle-deps-v1-{{ checksum \"build.gradle\" }}-{{ checksum \"app/build.gradle\" }}-{{ checksum \"gradle.properties\" }}-{{ checksum \"gradle/wrapper/gradle-wrapper.properties\" }}-{{ checksum \"settings.gradle\" }}-{{ checksum \"dependencies.gradle\" }}"
+  androidTest_gradle_deps_short: &androidTest_gradle_deps_short "androidTest-gradle-deps-v1-{{ checksum \"build.gradle\" }}-{{ checksum \"app/build.gradle\" }}-{{ checksum \"gradle.properties\" }}"
+  androidTest_gradle_deps_base:  &androidTest_gradle_deps_base  "androidTest-gradle-deps-v1-"
+  androidTest_android_sdk_full:  &androidTest_android_sdk_full  "androidTest-android-sdk-v1-{{ checksum \"build.gradle\" }}-{{ checksum \"app/build.gradle\" }}-{{ checksum \"gradle.properties\" }}"
+  androidTest_android_sdk_base:  &androidTest_android_sdk_base  "androidTest-android-sdk-v1-"
+
 executors:
   android_executor:
     machine:
@@ -31,13 +43,13 @@ jobs:
       - checkout
       - restore_cache: # For ~/.gradle directory (Gradle dependencies)
           keys:
-            - build-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
-            - build-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
-            - build-gradle-deps-v1-
+            - *build_gradle_deps_full
+            - *build_gradle_deps_short
+            - *build_gradle_deps_base
       - restore_cache: # For Android SDK components
           keys:
-            - build-android-sdk-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
-            - build-android-sdk-v1-
+            - *build_android_sdk_full
+            - *build_android_sdk_base
       - run:
           name: Create google-services.json (develop flavour)
           command: |
@@ -92,11 +104,11 @@ jobs:
       - save_cache:
           paths:
             - ~/.gradle
-          key: build-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
+          key: *build_gradle_deps_full
       - save_cache:
           paths:
             - ~/android-sdk
-          key: build-android-sdk-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
+          key: *build_android_sdk_full
 
   androidTest:
     parameters:
@@ -116,18 +128,18 @@ jobs:
       # cache entries for each key can only be created, they can't be updated.
       - restore_cache: # For ~/.gradle directory (Gradle dependencies) - try own cache first, then build job's cache
           keys:
-            - androidTest-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
-            - androidTest-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
-            - androidTest-gradle-deps-v1-
-            - build-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
-            - build-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
-            - build-gradle-deps-v1-
+            - *androidTest_gradle_deps_full
+            - *androidTest_gradle_deps_short
+            - *androidTest_gradle_deps_base
+            - *build_gradle_deps_full
+            - *build_gradle_deps_short
+            - *build_gradle_deps_base
       - restore_cache: # For Android SDK components - try own cache first, then build job's cache
           keys:
-            - androidTest-android-sdk-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
-            - androidTest-android-sdk-v1-
-            - build-android-sdk-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
-            - build-android-sdk-v1-
+            - *androidTest_android_sdk_full
+            - *androidTest_android_sdk_base
+            - *build_android_sdk_full
+            - *build_android_sdk_base
       - run:
           name: Remove old reports
           command: rm -fR build/reports app/build/reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,9 +170,6 @@ workflows:
               system_image:
                 - android-36;google_apis;x86_64
                 - android-26;google_apis;x86_64
-                - android-25;google_apis;x86_64
-                - android-24;google_apis;x86_64
-                - android-23;google_apis;x86_64
       - publish-github-release:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
           background: true
       - run:
           name: Wait for emulator to start
-          command: circle-android wait-for-boot
+          command: bin/waitForAndroidDeviceBoot
       - run:
           name: Disable emulator animations
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,5 @@
 version: 2.1
 
-# YAML anchors for cache-key checksum strings
-_cache_key_templates:
-  gradle_deps_checksum_full: &gradle_deps_checksum_full "{{ checksum \"build.gradle\" }}-{{ checksum \"app/build.gradle\" }}-{{ checksum \"gradle.properties\" }}-{{ checksum \"gradle/wrapper/gradle-wrapper.properties\" }}-{{ checksum \"settings.gradle\" }}-{{ checksum \"dependencies.gradle\" }}"
-  gradle_deps_checksum_short: &gradle_deps_checksum_short "{{ checksum \"build.gradle\" }}-{{ checksum \"app/build.gradle\" }}-{{ checksum \"gradle.properties\" }}"
-  android_sdk_checksum: &android_sdk_checksum "{{ checksum \"build.gradle\" }}-{{ checksum \"app/build.gradle\" }}-{{ checksum \"gradle.properties\" }}"
-
 # Circle CI doesn't offer a git-only way to share env. vars between jobs that use
 # different executors. Instead, use a YAML anchor.
 _shared_env_vars: &shared_env_vars
@@ -37,12 +31,12 @@ jobs:
       - checkout
       - restore_cache: # For ~/.gradle directory (Gradle dependencies)
           keys:
-            - build-gradle-deps-v1-*gradle_deps_checksum_full
-            - build-gradle-deps-v1-*gradle_deps_checksum_short
+            - build-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
+            - build-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
             - build-gradle-deps-v1-
       - restore_cache: # For Android SDK components
           keys:
-            - build-android-sdk-v1-*android_sdk_checksum
+            - build-android-sdk-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
             - build-android-sdk-v1-
       - run:
           name: Create google-services.json (develop flavour)
@@ -98,11 +92,11 @@ jobs:
       - save_cache:
           paths:
             - ~/.gradle
-          key: build-gradle-deps-v1-*gradle_deps_checksum_full
+          key: build-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
       - save_cache:
           paths:
             - ~/android-sdk
-          key: build-android-sdk-v1-*android_sdk_checksum
+          key: build-android-sdk-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
 
   androidTest:
     parameters:
@@ -120,19 +114,19 @@ jobs:
       # a cache from the build job if necessary. That's so this job can download extra dependencies
       # and cache them for next run. That's not possible if sharing a cache between jobs, since
       # cache entries for each key can only be created, they can't be updated.
-      - restore_cache: # For ~/.gradle directory (Gradle dependencies)
+      - restore_cache: # For ~/.gradle directory (Gradle dependencies) - try own cache first, then build job's cache
           keys:
-            - androidTest-gradle-deps-v1-*gradle_deps_checksum_full
-            - androidTest-gradle-deps-v1-*gradle_deps_checksum_short
+            - androidTest-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
+            - androidTest-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
             - androidTest-gradle-deps-v1-
-            - build-gradle-deps-v1-*gradle_deps_checksum_full
-            - build-gradle-deps-v1-*gradle_deps_checksum_short
+            - build-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
+            - build-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
             - build-gradle-deps-v1-
-      - restore_cache: # For Android SDK components
+      - restore_cache: # For Android SDK components - try own cache first, then build job's cache
           keys:
-            - androidTest-android-sdk-v1-*android_sdk_checksum
+            - androidTest-android-sdk-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
             - androidTest-android-sdk-v1-
-            - build-android-sdk-v1-*android_sdk_checksum
+            - build-android-sdk-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
             - build-android-sdk-v1-
       - run:
           name: Remove old reports
@@ -170,11 +164,11 @@ jobs:
       - save_cache:
           paths:
             - ~/.gradle
-          key: androidTest-gradle-deps-v1-*gradle_deps_checksum_full
+          key: androidTest-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
       - save_cache:
           paths:
             - ~/android-sdk
-          key: androidTest-android-sdk-v1-*android_sdk_checksum
+          key: androidTest-android-sdk-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
 
   publish-github-release:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+          key: jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
       - run:
           name: Create google-services.json (product flavour)
           command: |
@@ -36,7 +36,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.gradle
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+          key: jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
       - run:
           name: gradle check
           command: ./gradlew check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
           name: Remove old reports
           command: rm -fR build/reports app/build/reports
       - run:
-          name: Create avd
+          name: Create AVD
           command: |
             sdkmanager "${SYSTEM_IMAGE}"
             echo "no" | avdmanager --verbose create avd -n test -k "${SYSTEM_IMAGE}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,25 @@
 version: 2.1
 
+shared_env_vars: &shared_env_vars
+  JVM_OPTS: -Xmx3200m
+  ORG_GRADLE_PROJECT_RELEASE_STORE_FILE: /home/circleci/code/release.keystore
+  ORG_GRADLE_PROJECT_RELEASE_STORE_PASSWORD_FILE: /home/circleci/code/release.password
+  ORG_GRADLE_PROJECT_RELEASE_KEY_PASSWORD_FILE: /home/circleci/code/release.password
+
 executors:
   android_executor:
+    machine:
+      image: android:default
+    resource_class: large
+    environment:
+      <<: *shared_env_vars
+
+  build_executor:
     docker:
       - image: cimg/android:2025.08.1
     resource_class: large
     environment:
-      JVM_OPTS: -Xmx3200m
-      ORG_GRADLE_PROJECT_RELEASE_STORE_FILE: /home/circleci/code/release.keystore
-      ORG_GRADLE_PROJECT_RELEASE_STORE_PASSWORD_FILE: /home/circleci/code/release.password
-      ORG_GRADLE_PROJECT_RELEASE_KEY_PASSWORD_FILE: /home/circleci/code/release.password
+      <<: *shared_env_vars
 
 commands:
   cache_gradle_dependencies:
@@ -27,7 +37,7 @@ commands:
 jobs:
   build:
     working_directory: ~/code
-    executor: android_executor
+    executor: build_executor
     steps:
       - checkout
       - cache_gradle_dependencies
@@ -85,14 +95,8 @@ jobs:
       system_image:
         type: string
     working_directory: ~/code
-    machine:
-      image: android:default
-    resource_class: large
+    executor: android_executor
     environment:
-      JVM_OPTS: -Xmx3200m
-      ORG_GRADLE_PROJECT_RELEASE_STORE_FILE: /home/circleci/code/release.keystore
-      ORG_GRADLE_PROJECT_RELEASE_STORE_PASSWORD_FILE: /home/circleci/code/release.password
-      ORG_GRADLE_PROJECT_RELEASE_KEY_PASSWORD_FILE: /home/circleci/code/release.password
       SYSTEM_IMAGE: system-images;<< parameters.system_image >>
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,16 +17,15 @@ _cache_keys:
   androidTest_gradle_deps_base:  &androidTest_gradle_deps_base  "androidTest-gradle-deps-v1-"
 
 executors:
-  android_executor:
-    machine:
-      image: android:2024.11.1
-    resource_class: large
-    environment:
-      <<: *shared_env_vars
-
   build_executor:
     docker:
       - image: cimg/android:2025.08.1
+    resource_class: large
+    environment:
+      <<: *shared_env_vars
+  android_executor:
+    machine:
+      image: android:2024.11.1
     resource_class: large
     environment:
       <<: *shared_env_vars

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,9 +77,10 @@ jobs:
       - store_test_results: # https://circleci.com/docs/2.0/collect-test-data/
           path: app/build/test-results
       - persist_to_workspace:
-          root: app
+          root: .
           paths:
             - build
+            - app/build
   androidTest:
     parameters:
       system_image:
@@ -97,7 +98,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: ./app
+          at: .
       - cache_gradle_dependencies
       - create_google_services
       - run:
@@ -139,7 +140,7 @@ jobs:
       - image: cibuilds/github:0.13
     steps:
       - attach_workspace:
-          at: ./app
+          at: .
       - run:
           name: "Publish Release on GitHub"
           command: |
@@ -160,7 +161,7 @@ jobs:
             - ~/.rbenv
           key: rbenv-{{ checksum "Gemfile.lock" }}-{{ checksum "Gemfile" }}-{{ checksum ".ruby-version" }}
       - attach_workspace:
-          at: ./app
+          at: .
       - run:
           name: Create google-play-service.json
           command: printf "%s" "${GOOGLE_PLAY_SERVICE_JSON}" | base64 --decode > google-play-service.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,11 @@ jobs:
       - run:
           name: Wait for emulator to start
           command: |
-            circle-android wait-for-boot
+              adb wait-for-device
+              # Wait for the boot animation to finish and system to be ready
+              while [[ "$(adb shell getprop sys.boot_completed | tr -d '\r')" != "1" ]] ; do
+                sleep 1
+              done
       - run:
           name: Disable emulator animations
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
+            # Need to make sure downstream jobs have all the files they need to avoid gradle rebuilding the app.
             - app/src/develop/google-services.json
             - app/src/product/google-services.json
             - build
@@ -116,7 +117,7 @@ jobs:
       # a cache from the build job if necessary. That's so this job can download extra dependencies
       # and cache them for next run. That's not possible if sharing a cache between jobs, since
       # cache entries for each key can only be created, they can't be updated.
-      - restore_cache: # For ~/.gradle directory (Gradle dependencies) - try own cache first, then build job's cache
+      - restore_cache:
           name: Restoring cache - ~/.gradle
           keys:
             - *androidTest_gradle_deps_full

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
             adb shell settings put global animator_duration_scale 0.0
       - run:
           name: androidTest
-          command: ./gradlew connectedDebugAndroidTest
+          command: ./gradlew connectedProductDebugAndroidTest
   publish-github-release:
     docker:
       - image: cibuilds/github:0.13

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,9 @@ workflows:
             parameters:
               system_image:
                 - android-36;google_apis;x86_64
+                - android-26;google_apis;x86_64
+                - android-25;google_apis;x86_64
+                - android-24;google_apis;x86_64
                 - android-23;google_apis;x86_64
       - publish-github-release:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,9 @@ jobs:
       - run:
           name: gradle bundleProductRelease
           command: ./gradlew bundleProductRelease
+      - run:
+          name: gradle assembleProductDebugAndroidTest
+          command: ./gradlew assembleProductDebugAndroidTest
       - store_artifacts: # https://circleci.com/docs/2.0/artifacts/
           path: app/build/outputs/apk/product/release/app-product-release.apk
           destination: apks/app-product-release.apk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,8 @@ jobs:
             - app/src/product/google-services.json
             - build
             - app/build
+            - .gradle
+            - app/.gradle
   androidTest:
     parameters:
       system_image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,9 @@ jobs:
           paths:
             - build
   androidTest:
+    parameters:
+      system_image:
+        type: string
     working_directory: ~/code
     machine:
       image: android:default
@@ -96,9 +99,8 @@ jobs:
       - run:
           name: Create avd
           command: |
-            SYSTEM_IMAGE="system-images;android-36;google_apis;x86_64"
-            sdkmanager "${SYSTEM_IMAGE}"
-            echo "no" | avdmanager --verbose create avd -n test -k "${SYSTEM_IMAGE}"
+            sdkmanager << parameters.system_image >>
+            echo "no" | avdmanager --verbose create avd -n test -k << parameters.system_image >>
       - run:
           name: Launch emulator
           command: |
@@ -167,6 +169,10 @@ workflows:
       - androidTest:
           requires:
             - build
+          matrix:
+            system_image:
+              - system-images;android-36;google_apis;x86_64
+              - system-images;android-23;google_apis;x86_64
       - publish-github-release:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,9 @@ jobs:
           paths:
             - build
   androidTest:
+    parameters:
+      system_image:
+        type: string
     working_directory: ~/code
     machine:
       image: android:default
@@ -96,9 +99,8 @@ jobs:
       - run:
           name: Create avd
           command: |
-            SYSTEM_IMAGE="system-images;android-36;google_apis;x86_64"
-            sdkmanager "${SYSTEM_IMAGE}"
-            echo "no" | avdmanager --verbose create avd -n test -k "${SYSTEM_IMAGE}"
+            sdkmanager system-images;<< parameters.system_image >>
+            echo "no" | avdmanager --verbose create avd -n test -k system-images;<< parameters.system_image >>
       - run:
           name: Launch emulator
           command: |
@@ -167,6 +169,11 @@ workflows:
       - androidTest:
           requires:
             - build
+          matrix:
+            parameters:
+              system_image:
+                - android-36;google_apis;x86_64
+                - android-23;google_apis;x86_64
       - publish-github-release:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
           command: |
             SYSTEM_IMAGE="system-images;android-36;google_apis;x86_64"
             sdkmanager "${SYSTEM_IMAGE}"
-            echo "no" | avdmanager --verbose create avd -n test -k "${SYSTEM_IMAGES}"
+            echo "no" | avdmanager --verbose create avd -n test -k "${SYSTEM_IMAGE}"
       - run:
           name: Launch emulator
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,12 +109,7 @@ jobs:
           background: true
       - run:
           name: Wait for emulator to start
-          command: |
-              adb wait-for-device
-              # Wait for the boot animation to finish and system to be ready
-              while [[ "$(adb shell getprop sys.boot_completed | tr -d '\r')" != "1" ]] ; do
-                sleep 1
-              done
+          command: circle-android wait-for-boot
       - run:
           name: Disable emulator animations
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,8 +99,8 @@ jobs:
       - run:
           name: Create avd
           command: |
-            sdkmanager system-images;<< parameters.system_image >>
-            echo "no" | avdmanager --verbose create avd -n test -k system-images;<< parameters.system_image >>
+            sdkmanager "system-images;"<< parameters.system_image >>
+            echo "no" | avdmanager --verbose create avd -n test -k "system-images;"<< parameters.system_image >>
       - run:
           name: Launch emulator
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,10 @@ jobs:
           destination: aabs/app-product-release.aab
       - store_artifacts:
           path: app/build/reports
-          destination: reports
+          destination: reports/build/app
+      - store_artifacts:
+          path: build/reports
+          destination: reports/build/project
       - store_test_results: # https://circleci.com/docs/2.0/collect-test-data/
           path: app/build/test-results
       - persist_to_workspace:
@@ -98,6 +101,9 @@ jobs:
       - cache_gradle_dependencies
       - create_google_services
       - run:
+          name: remove old reports
+          command: rm -fR build/reports app/build/reports
+      - run:
           name: Create avd
           command: |
             sdkmanager "${SYSTEM_IMAGE}"
@@ -119,6 +125,15 @@ jobs:
       - run:
           name: androidTest
           command: ./gradlew connectedProductDebugAndroidTest
+      - store_artifacts:
+          path: app/build/reports
+          destination: reports/androidTest/<< parameters.system_image >>/app
+      - store_artifacts:
+          path: build/reports
+          destination: reports/androidTest/<< parameters.system_image >>/project
+      - store_test_results: # https://circleci.com/docs/2.0/collect-test-data/
+          path: app/build/outputs/androidTest-results/connected/debug/flavors/product/
+
   publish-github-release:
     docker:
       - image: cibuilds/github:0.13

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,10 +74,9 @@ jobs:
       - store_test_results: # https://circleci.com/docs/2.0/collect-test-data/
           path: app/build/test-results
       - persist_to_workspace:
-          root: app/build
+          root: app
           paths:
-            - version
-            - outputs
+            - build
   androidTest:
     working_directory: ~/code
     machine:
@@ -91,7 +90,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: ./app/build
+          at: ./app
       - cache_gradle_dependencies
       - create_google_services
       - run:
@@ -127,7 +126,7 @@ jobs:
       - image: cibuilds/github:0.13
     steps:
       - attach_workspace:
-          at: ./app/build
+          at: ./app
       - run:
           name: "Publish Release on GitHub"
           command: |
@@ -148,7 +147,7 @@ jobs:
             - ~/.rbenv
           key: rbenv-{{ checksum "Gemfile.lock" }}-{{ checksum "Gemfile" }}-{{ checksum ".ruby-version" }}
       - attach_workspace:
-          at: ./app/build
+          at: ./app
       - run:
           name: Create google-play-service.json
           command: printf "%s" "${GOOGLE_PLAY_SERVICE_JSON}" | base64 --decode > google-play-service.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,8 @@ _cache_key_templates:
   android_sdk_checksum: &android_sdk_checksum "{{ checksum \"build.gradle\" }}-{{ checksum \"app/build.gradle\" }}-{{ checksum \"gradle.properties\" }}"
 
 # Circle CI doesn't offer a git-only way to share env. vars between jobs that use
-# different executors. Instead, add a non-standard shared_env_vars config and
-# use a YAML anchor.
-shared_env_vars: &shared_env_vars
+# different executors. Instead, use a YAML anchor.
+_shared_env_vars: &shared_env_vars
   JVM_OPTS: -Xmx3200m
   ORG_GRADLE_PROJECT_RELEASE_STORE_FILE: /home/circleci/code/release.keystore
   ORG_GRADLE_PROJECT_RELEASE_STORE_PASSWORD_FILE: /home/circleci/code/release.password

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ jobs:
             adb shell settings put global animator_duration_scale 0.0
       - run:
           name: androidTest
-          command: ./gradlew connectedProductDebugAndroidTest --scan
+          command: ./gradlew connectedProductDebugAndroidTest
       - store_artifacts:
           path: app/build/reports
           destination: reports/app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
           at: .
       - cache_gradle_dependencies
       - run:
-          name: remove old reports
+          name: Remove old reports
           command: rm -fR build/reports app/build/reports
       - run:
           name: Create avd

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,9 +170,10 @@ workflows:
           requires:
             - build
           matrix:
-            system_image:
-              - system-images;android-36;google_apis;x86_64
-              - system-images;android-23;google_apis;x86_64
+            parameters:
+              system_image:
+                - system-images;android-36;google_apis;x86_64
+                - system-images;android-23;google_apis;x86_64
       - publish-github-release:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
           name: Saving cache - ~/.gradle
           paths:
             - ~/.gradle
-          key: androidTest-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
+          key: *androidTest_gradle_deps_full
 
   publish-github-release:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,14 @@ commands:
           paths:
             - ~/.gradle
           key: jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
-  create_google_services:
+
+jobs:
+  build:
+    working_directory: ~/code
+    executor: android_executor
     steps:
+      - checkout
+      - cache_gradle_dependencies
       - run:
           name: Create google-services.json (develop flavour)
           command: |
@@ -35,15 +41,6 @@ commands:
           command: |
             rm app/src/product/google-services.json # symlink, for local builds
             printf "%s" "${GOOGLE_SERVICES}" | base64 --decode > app/src/product/google-services.json
-
-jobs:
-  build:
-    working_directory: ~/code
-    executor: android_executor
-    steps:
-      - checkout
-      - cache_gradle_dependencies
-      - create_google_services
       - run:
           name: Create release.password
           command: printf "%s\n" "${RELEASE_KEY_PASSWORD:-}" > "${ORG_GRADLE_PROJECT_RELEASE_KEY_PASSWORD_FILE}"
@@ -79,6 +76,8 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
+            - app/src/develop/google-services.json
+            - app/src/product/google-services.json
             - build
             - app/build
   androidTest:
@@ -100,7 +99,6 @@ jobs:
       - attach_workspace:
           at: .
       - cache_gradle_dependencies
-      - create_google_services
       - run:
           name: remove old reports
           command: rm -fR build/reports app/build/reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+# Circle CI doesn't offer a git-only way to share env. vars between jobs that use
+# different executors. Instead, add a non-standard shared_env_vars config and
+# use a YAML anchor.
 shared_env_vars: &shared_env_vars
   JVM_OPTS: -Xmx3200m
   ORG_GRADLE_PROJECT_RELEASE_STORE_FILE: /home/circleci/code/release.keystore

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ _cache_keys:
 executors:
   android_executor:
     machine:
-      image: android:default
+      image: android:2024.11.1
     resource_class: large
     environment:
       <<: *shared_env_vars

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ executors:
     resource_class: large
     environment:
       JVM_OPTS: -Xmx3200m
+      ORG_GRADLE_PROJECT_RELEASE_STORE_FILE: /home/circleci/code/release.keystore
+      ORG_GRADLE_PROJECT_RELEASE_STORE_PASSWORD_FILE: /home/circleci/code/release.password
+      ORG_GRADLE_PROJECT_RELEASE_KEY_PASSWORD_FILE: /home/circleci/code/release.password
 
 commands:
   cache_gradle_dependencies:
@@ -32,10 +35,6 @@ jobs:
   build:
     working_directory: ~/code
     executor: android_executor
-    environment:
-      ORG_GRADLE_PROJECT_RELEASE_STORE_FILE: /home/circleci/code/release.keystore
-      ORG_GRADLE_PROJECT_RELEASE_STORE_PASSWORD_FILE: /home/circleci/code/release.password
-      ORG_GRADLE_PROJECT_RELEASE_KEY_PASSWORD_FILE: /home/circleci/code/release.password
     steps:
       - checkout
       - cache_gradle_dependencies
@@ -79,6 +78,39 @@ jobs:
           paths:
             - version
             - outputs
+  androidTest:
+    working_directory: ~/code
+    executor: android_executor
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./app/build
+      - cache_gradle_dependencies
+      - run:
+        name: Create avd
+        command: |
+          SYSTEM_IMAGE="system-images;android-36;google_apis;x86_64"
+          sdkmanager "${SYSTEM_IMAGE}"
+          echo "no" | avdmanager --verbose create avd -n test -k "${SYSTEM_IMAGES}"
+      - run:
+          name: Launch emulator
+          command: |
+            emulator -avd test -delay-adb -verbose -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
+          background: true
+      - run:
+          name: Wait for emulator to start
+          command: |
+            circle-android wait-for-boot
+      - run:
+          name: Disable emulator animations
+          command: |
+            adb shell settings put global window_animation_scale 0.0
+            adb shell settings put global transition_animation_scale 0.0
+            adb shell settings put global animator_duration_scale 0.0
+      - run:
+          name: androidTest
+          command: ./gradlew connectedDebugAndroidTest
+
   publish-github-release:
     docker:
       - image: cibuilds/github:0.13
@@ -122,6 +154,9 @@ workflows:
   all:
     jobs:
       - build
+      - androidTest:
+          requires:
+            - build
       - publish-github-release:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,24 @@
 version: 2
+commands:
+  cache_gradle_dependencies:
+    steps:
+      - restore_cache:
+          key: jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
+      - run:
+          name: Download Dependencies
+          command: ./gradlew androidDependencies
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
+  create_google_services_develop:
+    steps:
+      - run:
+          name: Create google-services.json (develop flavour)
+          command: |
+            rm app/src/develop/google-services.json # symlink, for local builds
+            printf "%s" "${GOOGLE_SERVICES_DEVELOP}" | base64 --decode > app/src/develop/google-services.json      
+
 jobs:
   build:
     working_directory: ~/code
@@ -12,31 +32,19 @@ jobs:
       ORG_GRADLE_PROJECT_RELEASE_KEY_PASSWORD_FILE: /home/circleci/code/release.password
     steps:
       - checkout
-      - restore_cache:
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
+      - cache_gradle_dependencies
+      - create_google_services_develop
       - run:
           name: Create google-services.json (product flavour)
           command: |
             rm app/src/product/google-services.json # symlink, for local builds
             printf "%s" "${GOOGLE_SERVICES}" | base64 --decode > app/src/product/google-services.json
       - run:
-          name: Create google-services.json (develop flavour)
-          command: |
-            rm app/src/develop/google-services.json # symlink, for local builds
-            printf "%s" "${GOOGLE_SERVICES_DEVELOP}" | base64 --decode > app/src/develop/google-services.json
-      - run:
           name: Create release.password
           command: printf "%s\n" "${RELEASE_KEY_PASSWORD:-}" > "${ORG_GRADLE_PROJECT_RELEASE_KEY_PASSWORD_FILE}"
       - run:
           name: Create release.keystore
           command: printf "%s" "${RELEASE_KEYSTORE:-}" | base64 --decode > "${ORG_GRADLE_PROJECT_RELEASE_STORE_FILE}"
-      - run:
-          name: Download Dependencies
-          command: ./gradlew androidDependencies
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
       - run:
           name: gradle check
           command: ./gradlew check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,12 +41,14 @@ jobs:
     executor: build_executor
     steps:
       - checkout
-      - restore_cache: # For ~/.gradle directory (Gradle dependencies)
+      - restore_cache:
+          name: Restoring cache - ~/.gradle
           keys:
             - *build_gradle_deps_full
             - *build_gradle_deps_short
             - *build_gradle_deps_base
-      - restore_cache: # For Android SDK components
+      - restore_cache:
+          name: Restoring cache - Android SDK
           keys:
             - *build_android_sdk_full
             - *build_android_sdk_base
@@ -102,10 +104,12 @@ jobs:
             - .gradle
             - app/.gradle
       - save_cache:
+          name: Saving cache - ~/.gradle
           paths:
             - ~/.gradle
           key: *build_gradle_deps_full
       - save_cache:
+          name: Saving cache - Android SDK
           paths:
             - ~/android-sdk
           key: *build_android_sdk_full
@@ -127,6 +131,7 @@ jobs:
       # and cache them for next run. That's not possible if sharing a cache between jobs, since
       # cache entries for each key can only be created, they can't be updated.
       - restore_cache: # For ~/.gradle directory (Gradle dependencies) - try own cache first, then build job's cache
+          name: Restoring cache - ~/.gradle
           keys:
             - *androidTest_gradle_deps_full
             - *androidTest_gradle_deps_short
@@ -134,7 +139,8 @@ jobs:
             - *build_gradle_deps_full
             - *build_gradle_deps_short
             - *build_gradle_deps_base
-      - restore_cache: # For Android SDK components - try own cache first, then build job's cache
+      - restore_cache:
+          name: Restoring cache - Android SDK
           keys:
             - *androidTest_android_sdk_full
             - *androidTest_android_sdk_base
@@ -174,10 +180,12 @@ jobs:
       - store_test_results: # https://circleci.com/docs/2.0/collect-test-data/
           path: app/build/outputs/androidTest-results/connected/debug/flavors/product/
       - save_cache:
+          name: Saving cache - ~/.gradle
           paths:
             - ~/.gradle
           key: androidTest-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
       - save_cache:
+          name: Saving cache - Android SDK
           paths:
             - ~/android-sdk
           key: androidTest-android-sdk-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,13 +23,18 @@ commands:
           paths:
             - ~/.gradle
           key: jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
-  create_google_services_develop:
+  create_google_services:
     steps:
       - run:
           name: Create google-services.json (develop flavour)
           command: |
             rm app/src/develop/google-services.json # symlink, for local builds
-            printf "%s" "${GOOGLE_SERVICES_DEVELOP}" | base64 --decode > app/src/develop/google-services.json      
+            printf "%s" "${GOOGLE_SERVICES_DEVELOP}" | base64 --decode > app/src/develop/google-services.json
+      - run:
+          name: Create google-services.json (product flavour)
+          command: |
+            rm app/src/product/google-services.json # symlink, for local builds
+            printf "%s" "${GOOGLE_SERVICES}" | base64 --decode > app/src/product/google-services.json
 
 jobs:
   build:
@@ -38,12 +43,7 @@ jobs:
     steps:
       - checkout
       - cache_gradle_dependencies
-      - create_google_services_develop
-      - run:
-          name: Create google-services.json (product flavour)
-          command: |
-            rm app/src/product/google-services.json # symlink, for local builds
-            printf "%s" "${GOOGLE_SERVICES}" | base64 --decode > app/src/product/google-services.json
+      - create_google_services
       - run:
           name: Create release.password
           command: printf "%s\n" "${RELEASE_KEY_PASSWORD:-}" > "${ORG_GRADLE_PROJECT_RELEASE_KEY_PASSWORD_FILE}"
@@ -93,6 +93,7 @@ jobs:
       - attach_workspace:
           at: ./app/build
       - cache_gradle_dependencies
+      - create_google_services
       - run:
           name: Create avd
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,11 @@
 version: 2.1
 
+# YAML anchors for cache-key checksum strings
+_cache_key_templates:
+  gradle_deps_checksum_full: &gradle_deps_checksum_full "{{ checksum \"build.gradle\" }}-{{ checksum \"app/build.gradle\" }}-{{ checksum \"gradle.properties\" }}-{{ checksum \"gradle/wrapper/gradle-wrapper.properties\" }}-{{ checksum \"settings.gradle\" }}-{{ checksum \"dependencies.gradle\" }}"
+  gradle_deps_checksum_short: &gradle_deps_checksum_short "{{ checksum \"build.gradle\" }}-{{ checksum \"app/build.gradle\" }}-{{ checksum \"gradle.properties\" }}"
+  android_sdk_checksum: &android_sdk_checksum "{{ checksum \"build.gradle\" }}-{{ checksum \"app/build.gradle\" }}-{{ checksum \"gradle.properties\" }}"
+
 # Circle CI doesn't offer a git-only way to share env. vars between jobs that use
 # different executors. Instead, add a non-standard shared_env_vars config and
 # use a YAML anchor.
@@ -32,12 +38,12 @@ jobs:
       - checkout
       - restore_cache: # For ~/.gradle directory (Gradle dependencies)
           keys:
-            - build-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
-            - build-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
+            - build-gradle-deps-v1-*gradle_deps_checksum_full
+            - build-gradle-deps-v1-*gradle_deps_checksum_short
             - build-gradle-deps-v1-
       - restore_cache: # For Android SDK components
           keys:
-            - build-android-sdk-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
+            - build-android-sdk-v1-*android_sdk_checksum
             - build-android-sdk-v1-
       - run:
           name: Create google-services.json (develop flavour)
@@ -93,11 +99,11 @@ jobs:
       - save_cache:
           paths:
             - ~/.gradle
-          key: build-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
+          key: build-gradle-deps-v1-*gradle_deps_checksum_full
       - save_cache:
           paths:
             - ~/android-sdk
-          key: build-android-sdk-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
+          key: build-android-sdk-v1-*android_sdk_checksum
 
   androidTest:
     parameters:
@@ -115,19 +121,19 @@ jobs:
       # a cache from the build job if necessary. That's so this job can download extra dependencies
       # and cache them for next run. That's not possible if sharing a cache between jobs, since
       # cache entries for each key can only be created, they can't be updated.
-      - restore_cache: # For ~/.gradle directory (Gradle dependencies) - try own cache first, then build job's cache
+      - restore_cache: # For ~/.gradle directory (Gradle dependencies)
           keys:
-            - androidTest-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
-            - androidTest-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
+            - androidTest-gradle-deps-v1-*gradle_deps_checksum_full
+            - androidTest-gradle-deps-v1-*gradle_deps_checksum_short
             - androidTest-gradle-deps-v1-
-            - build-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
-            - build-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
+            - build-gradle-deps-v1-*gradle_deps_checksum_full
+            - build-gradle-deps-v1-*gradle_deps_checksum_short
             - build-gradle-deps-v1-
-      - restore_cache: # For Android SDK components - try own cache first, then build job's cache
+      - restore_cache: # For Android SDK components
           keys:
-            - androidTest-android-sdk-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
+            - androidTest-android-sdk-v1-*android_sdk_checksum
             - androidTest-android-sdk-v1-
-            - build-android-sdk-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
+            - build-android-sdk-v1-*android_sdk_checksum
             - build-android-sdk-v1-
       - run:
           name: Remove old reports
@@ -165,11 +171,11 @@ jobs:
       - save_cache:
           paths:
             - ~/.gradle
-          key: androidTest-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
+          key: androidTest-gradle-deps-v1-*gradle_deps_checksum_full
       - save_cache:
           paths:
             - ~/android-sdk
-          key: androidTest-android-sdk-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
+          key: androidTest-android-sdk-v1-*android_sdk_checksum
 
   publish-github-release:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,26 +24,21 @@ executors:
     environment:
       <<: *shared_env_vars
 
-commands:
-  cache_gradle_dependencies:
-    steps:
-      - restore_cache:
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
-      - run:
-          name: Download Dependencies
-          command: ./gradlew androidDependencies
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
-
 jobs:
   build:
     working_directory: ~/code
     executor: build_executor
     steps:
       - checkout
-      - cache_gradle_dependencies
+      - restore_cache: # For ~/.gradle directory (Gradle dependencies)
+          keys:
+            - build-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
+            - build-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
+            - build-gradle-deps-v1-
+      - restore_cache: # For Android SDK components
+          keys:
+            - build-android-sdk-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
+            - build-android-sdk-v1-
       - run:
           name: Create google-services.json (develop flavour)
           command: |
@@ -95,6 +90,15 @@ jobs:
             - app/build
             - .gradle
             - app/.gradle
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: build-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
+      - save_cache:
+          paths:
+            - ~/android-sdk
+          key: build-android-sdk-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
+
   androidTest:
     parameters:
       system_image:
@@ -107,7 +111,24 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - cache_gradle_dependencies
+      # Cache restoration uses androidTest-specific cache if possible, falling back to
+      # a cache from the build job if necessary. That's so this job can download extra dependencies
+      # and cache them for next run. That's not possible if sharing a cache between jobs, since
+      # cache entries for each key can only be created, they can't be updated.
+      - restore_cache: # For ~/.gradle directory (Gradle dependencies) - try own cache first, then build job's cache
+          keys:
+            - androidTest-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
+            - androidTest-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
+            - androidTest-gradle-deps-v1-
+            - build-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
+            - build-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
+            - build-gradle-deps-v1-
+      - restore_cache: # For Android SDK components - try own cache first, then build job's cache
+          keys:
+            - androidTest-android-sdk-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
+            - androidTest-android-sdk-v1-
+            - build-android-sdk-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
+            - build-android-sdk-v1-
       - run:
           name: Remove old reports
           command: rm -fR build/reports app/build/reports
@@ -141,6 +162,14 @@ jobs:
           destination: reports/project
       - store_test_results: # https://circleci.com/docs/2.0/collect-test-data/
           path: app/build/outputs/androidTest-results/connected/debug/flavors/product/
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: androidTest-gradle-deps-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "settings.gradle" }}-{{ checksum "dependencies.gradle" }}
+      - save_cache:
+          paths:
+            - ~/android-sdk
+          key: androidTest-android-sdk-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}-{{ checksum "gradle.properties" }}
 
   publish-github-release:
     docker:
@@ -205,4 +234,3 @@ workflows:
           filters:
             branches:
               only: release
-

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /.idea/modules.xml
 /.idea/workspace.xml
 /.idea/navEditor.xml
+/.idea/androidTestResultsUserPreferences.xml
 /.idea/assetWizardSettings.xml
 .DS_Store
 /build

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -5,6 +5,9 @@
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
+      <SelectionState runConfigName="AppTest">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ It's using:
 * [Fastlane](https://fastlane.tools/) to publish the app to google play store as an internal testing release for every commit on the release branch.
 * [Material Design](https://material.io/design/).
 * [detekt](https://detekt.dev/) for kotlin static analysis.
+* AndroidComposeTestRule for UI testing.
 
 ## Development Environment
 

--- a/TODO
+++ b/TODO
@@ -5,6 +5,7 @@
   X use specific android machine image on CI
   X test on minSdkVersion and latest android version
   X save androidTest /home/circleci/code/build/reports/problems/problems-report.html
+  X sort out duplicated env. var. config
   - androidTest jobs are rebuilding app
     - try passing google-services.json in workspace
       - to ensure timestamp same
@@ -12,7 +13,6 @@
       - build with android VM not docker?
     - different SDKs?
       - caching likely helps, though seems a little fragile
-  - sort out duplicated executor config
   - cache android SDK files / AVDs
 
 * Add store_test_results steps

--- a/TODO
+++ b/TODO
@@ -5,7 +5,7 @@
   X use specific android machine image on CI
   - sort out duplicated executor config
   - add store_test_results steps
-  X test on minSdkVersion and latest android version
+  - test on minSdkVersion and latest android version
   - save androidTest /home/circleci/code/build/reports/problems/problems-report.html
   - cache android SDK files / AVDs
   - record logcat

--- a/TODO
+++ b/TODO
@@ -119,6 +119,8 @@
 
 * App link gives "Item not found" error in play store app if android platform is too old.
 
+* Run shellcheck on CI.
+
 * Better play store text etc.
   - short and long description shouldn't be the same.
 

--- a/TODO
+++ b/TODO
@@ -2,8 +2,10 @@
   X add minimal test
   X run the test on Circle CI
     X https://circleci.com/docs/guides/execution-managed/android-machine-image/
-  - use specific android machine image on CI
+  X use specific android machine image on CI
   - sort out duplicated executor config
+  - add store_test_results steps
+  - save androidTest /home/circleci/code/build/reports/problems/problems-report.html
   - cache android SDK files / AVDs
   - record logcat
 

--- a/TODO
+++ b/TODO
@@ -5,7 +5,7 @@
   X use specific android machine image on CI
   - sort out duplicated executor config
   - add store_test_results steps
-  - test on minSdkVersion and latest android version
+  X test on minSdkVersion and latest android version
   - save androidTest /home/circleci/code/build/reports/problems/problems-report.html
   - cache android SDK files / AVDs
   - record logcat

--- a/TODO
+++ b/TODO
@@ -5,7 +5,13 @@
   X use specific android machine image on CI
   X test on minSdkVersion and latest android version
   X save androidTest /home/circleci/code/build/reports/problems/problems-report.html
-  - androidTest jobs seem to be rebuilding app?
+  - androidTest jobs are rebuilding app
+    - try passing google-services.json in workspace
+      - to ensure timestamp same
+    - different machine images?
+      - build with android VM not docker?
+    - different SDKs?
+      - caching likely helps, though seems a little fragile
   - sort out duplicated executor config
   - cache android SDK files / AVDs
 

--- a/TODO
+++ b/TODO
@@ -3,14 +3,20 @@
   X run the test on Circle CI
     X https://circleci.com/docs/guides/execution-managed/android-machine-image/
   X use specific android machine image on CI
-  - sort out duplicated executor config
-  - add store_test_results steps
   X test on minSdkVersion and latest android version
+  - sort out duplicated executor config
   - save androidTest /home/circleci/code/build/reports/problems/problems-report.html
   - cache android SDK files / AVDs
-  - record logcat
-  - ping emulator at end of job (even if job fails
-  - rerun job if ping fails
+
+* Add store_test_results steps
+  - unit tests
+  - end-to-end tests
+
+* Record logcat when running tests
+
+* Ping emulator at end of job (even if job fails)
+  - circle ci doesn't offer suitable job retries yet
+    - https://circleci.canny.io/cloud-feature-requests/p/job-triggered-retries
 
 * git status checks
   - will need to adjust scripts that delete checked-in google-services.json symlinks

--- a/TODO
+++ b/TODO
@@ -80,6 +80,14 @@
 
 * An ErrorReporter that crashes debug/staging builds, but sends errors to firebase in production.
 
+* Circle CI CLI
+  - README
+    - mention installation instructions
+    - useful for validating config locally
+  - configure shell completion in environment script
+    - eval "$(circleci completion bash)"
+    - conditional on circleci being installed
+
 * Multiple faces
   - can only detect one face if contour-detection enabled.
   - options

--- a/TODO
+++ b/TODO
@@ -4,7 +4,7 @@
     X https://circleci.com/docs/guides/execution-managed/android-machine-image/
   X use specific android machine image on CI
   X test on minSdkVersion and latest android version
-  - save androidTest /home/circleci/code/build/reports/problems/problems-report.html
+  X save androidTest /home/circleci/code/build/reports/problems/problems-report.html
   - androidTest jobs seem to be rebuilding app?
   - sort out duplicated executor config
   - cache android SDK files / AVDs

--- a/TODO
+++ b/TODO
@@ -4,8 +4,9 @@
     X https://circleci.com/docs/guides/execution-managed/android-machine-image/
   X use specific android machine image on CI
   X test on minSdkVersion and latest android version
-  - sort out duplicated executor config
   - save androidTest /home/circleci/code/build/reports/problems/problems-report.html
+  - androidTest jobs seem to be rebuilding app?
+  - sort out duplicated executor config
   - cache android SDK files / AVDs
 
 * Add store_test_results steps
@@ -139,6 +140,10 @@
   - git tag for each release
     - locally before pushing or from CI?
     - ...but something is already adding git tags - what?
+
+* androidTest job is using debug build not release
+  - testBuildType can be set to release
+  - might be issues from obfuscation?
 
 * Google Play store console says, "your app is using an old version of the Google Play developer API".
   - https://android-developers.googleblog.com/2019/03/changes-to-google-play-developer-api.html

--- a/TODO
+++ b/TODO
@@ -1,20 +1,19 @@
 * End-to-end tests
-  - https://circleci.com/docs/guides/execution-managed/android-machine-image/
-  - espresso?
-    - only for Views
-  - AndroidComposeTestRule?
-    - https://developer.android.com/jetpack/compose/testing
-    - https://developer.android.com/develop/ui/compose/testing
-    - can it do end-to-end testing of app?
-    - docs have tests an arbitrary Composable (and arbitrary Activity)
-    - might be able to test a single-Activity app too?
-    - multiple Activity app harder
-      - ActivityScenario?
-      - use espresso too?
-      - likely easier to migrate to single Activity app?
-  - UI automator 2?
-    - for interaction with camera?
-    - might be able to combine with compose test API / espresso?
+  X add minimal test
+  - run the test on Circle CI
+    - https://circleci.com/docs/guides/execution-managed/android-machine-image/
+
+* Single Activity app
+  - merge the various activities
+  - use JetPack Compose navigation instead
+
+* More end-to-end testing
+  - test login flow
+  - test licence screen
+  - test app version screen
+  - test interaction with camera app
+    - does that need UI Automator?
+    - can that be interleaved with other testing APIs?
   - allowing sharing of images to app would make testing easier.
 
 * Unit tests.

--- a/TODO
+++ b/TODO
@@ -3,6 +3,9 @@
   - run the test on Circle CI
     - https://circleci.com/docs/guides/execution-managed/android-machine-image/
 
+* git status checks
+  - will need to adjust scripts that delete checked-in google-services.json symlinks
+
 * Single Activity app
   - merge the various activities
   - use JetPack Compose navigation instead

--- a/TODO
+++ b/TODO
@@ -223,3 +223,5 @@
   - https://developers.google.com/ml-kit/vision/face-detection/android#using-a-media.image
 
 * Add "Developer page" for app on google play console.
+
+* Move src/main/java to src/main/kotlin?

--- a/TODO
+++ b/TODO
@@ -84,6 +84,9 @@
 
 * An ErrorReporter that crashes debug/staging builds, but sends errors to firebase in production.
 
+* bin/setup checks .ruby-version and .circleci/config.yml agree on ruby version
+  - it'd be better to check in a CI job
+
 * Circle CI CLI
   - README
     - mention installation instructions

--- a/TODO
+++ b/TODO
@@ -1,7 +1,8 @@
 * End-to-end tests
   X add minimal test
-  - run the test on Circle CI
-    - https://circleci.com/docs/guides/execution-managed/android-machine-image/
+  X run the test on Circle CI
+    X https://circleci.com/docs/guides/execution-managed/android-machine-image/
+  - cache android SDK files / AVDs
 
 * git status checks
   - will need to adjust scripts that delete checked-in google-services.json symlinks

--- a/TODO
+++ b/TODO
@@ -1,3 +1,6 @@
+* Pass all files in Circle CI workspace?
+  - less fragile way of avoiding gradle rebuilds in androidTest jobs.
+
 * Record logcat when running tests
 
 * Ping emulator at end of job (even if job fails)

--- a/TODO
+++ b/TODO
@@ -1,3 +1,10 @@
+* End-to-end tests
+  - https://circleci.com/docs/guides/execution-managed/android-machine-image/
+  - espresso?
+  - UI automator 2?
+    - for interaction with camera?
+  - allowing sharing of images to app would make testing easier.
+
 * Any ordering issues from use of coroutine dispatchers in AppViewModel?
 
 * Add entity diagram to README
@@ -130,12 +137,6 @@
   - use androidx DialogFragment?
 
 * Toggleable overlay showing debug info.
-
-* End-to-end tests
-  - espresso?
-  - UI automator 2?
-    - for interaction with camera?
-  - allowing sharing of images to app would make testing easier.
 
 * Add more Firebase Analytics events.
   - https://firebase.google.com/docs/analytics/android/start

--- a/TODO
+++ b/TODO
@@ -6,14 +6,12 @@
   X test on minSdkVersion and latest android version
   X save androidTest /home/circleci/code/build/reports/problems/problems-report.html
   X sort out duplicated env. var. config
-  - androidTest jobs are rebuilding app
-    - try passing google-services.json in workspace
-      - to ensure timestamp same
-    - different machine images?
-      - build with android VM not docker?
-    - different SDKs?
-      - caching likely helps, though seems a little fragile
+  X androidTest jobs are rebuilding app
   - cache android SDK files / AVDs
+    - still downloading SDK components.
+    - need separate cache per SYSTEM_IMAGE
+      - does that mean need to inline the YAML anchors for this cache?
+    - restoration is maybe not much faster than fresh download?
 
 * Add store_test_results steps
   - unit tests

--- a/TODO
+++ b/TODO
@@ -1,9 +1,28 @@
 * End-to-end tests
   - https://circleci.com/docs/guides/execution-managed/android-machine-image/
   - espresso?
+    - only for Views
+  - AndroidComposeTestRule?
+    - https://developer.android.com/jetpack/compose/testing
+    - https://developer.android.com/develop/ui/compose/testing
+    - can it do end-to-end testing of app?
+    - docs have tests an arbitrary Composable (and arbitrary Activity)
+    - might be able to test a single-Activity app too?
+    - multiple Activity app harder
+      - ActivityScenario?
+      - use espresso too?
+      - likely easier to migrate to single Activity app?
   - UI automator 2?
     - for interaction with camera?
+    - might be able to combine with compose test API / espresso?
   - allowing sharing of images to app would make testing easier.
+
+* Unit tests.
+  - write some
+  - run from test server
+  - coverage report
+
+* https://developer.android.com/studio/preview/compose-screenshot-testing
 
 * Any ordering issues from use of coroutine dispatchers in AppViewModel?
 
@@ -114,11 +133,6 @@
 * Enable crashlytics and analytics in SplashActivity if previously enabled via OnboardingActivity.
   - currently, enable in MainActivity, which avoids need to persist state, but means
     early crashes not visible.
-
-* Unit tests.
-  - write some
-  - run from test server
-  - coverage report
 
 * Garbage collect files after delete them and UI has finished updating.
   - when ViewPager2 stops using them

--- a/TODO
+++ b/TODO
@@ -9,6 +9,8 @@
   - save androidTest /home/circleci/code/build/reports/problems/problems-report.html
   - cache android SDK files / AVDs
   - record logcat
+  - ping emulator at end of job (even if job fails
+  - rerun job if ping fails
 
 * git status checks
   - will need to adjust scripts that delete checked-in google-services.json symlinks

--- a/TODO
+++ b/TODO
@@ -80,6 +80,11 @@
   - call data clearing APIs.
   - go back to SplashActivity if change setting
 
+* Circle CI tests all commits
+  - i.e. if check in faster than can run builds and tests, get multiple builds running concurrently
+  - does this exhaust any quota?
+  - change to only run on workflow at once?
+
 * NDK crash reporting
 
 * An ErrorReporter that crashes debug/staging builds, but sends errors to firebase in production.

--- a/TODO
+++ b/TODO
@@ -5,6 +5,7 @@
   X use specific android machine image on CI
   - sort out duplicated executor config
   - add store_test_results steps
+  - test on minSdkVersion and latest android version
   - save androidTest /home/circleci/code/build/reports/problems/problems-report.html
   - cache android SDK files / AVDs
   - record logcat

--- a/TODO
+++ b/TODO
@@ -2,7 +2,10 @@
   X add minimal test
   X run the test on Circle CI
     X https://circleci.com/docs/guides/execution-managed/android-machine-image/
+  - use specific android machine image on CI
+  - sort out duplicated executor config
   - cache android SDK files / AVDs
+  - record logcat
 
 * git status checks
   - will need to adjust scripts that delete checked-in google-services.json symlinks

--- a/TODO
+++ b/TODO
@@ -1,22 +1,3 @@
-* End-to-end tests
-  X add minimal test
-  X run the test on Circle CI
-    X https://circleci.com/docs/guides/execution-managed/android-machine-image/
-  X use specific android machine image on CI
-  X test on minSdkVersion and latest android version
-  X save androidTest /home/circleci/code/build/reports/problems/problems-report.html
-  X sort out duplicated env. var. config
-  X androidTest jobs are rebuilding app
-  - cache android SDK files / AVDs
-    - still downloading SDK components.
-    - need separate cache per SYSTEM_IMAGE
-      - does that mean need to inline the YAML anchors for this cache?
-    - restoration is maybe not much faster than fresh download?
-
-* Add store_test_results steps
-  - unit tests
-  - end-to-end tests
-
 * Record logcat when running tests
 
 * Ping emulator at end of job (even if job fails)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,7 +59,7 @@ android {
     compileSdk=36
     defaultConfig {
         applicationId "uk.me.jeremygreen.merging2"
-        minSdkVersion 23
+        minSdkVersion 26
         targetSdkVersion 36
         versionCode findVersionCode()
         versionName findVersionName()

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,6 +46,7 @@ static String findVersionName() {
 }
 
 def releaseStoreFile = file(RELEASE_STORE_FILE, PathValidation.NONE)
+def isCI = System.getenv().containsKey("CI")
 
 // On CI, the files are only created for jobs that really need them, but still need to be
 // able to run unrelated gradle tasks.
@@ -101,6 +102,14 @@ android {
         }
     }
     namespace = 'uk.me.jeremygreen.merging2'
+}
+
+gradleEnterprise {
+    buildScan {
+        uploadInBackground = !isCI
+        termsOfServiceUrl = "https://gradle.com/help/legal-terms-of-use"
+        termsOfServiceAgree = "yes"
+    }
 }
 
 detekt {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -154,7 +154,7 @@ dependencies {
     detektPlugins 'io.nlopez.compose.rules:detekt:0.4.27'
 }
 
-task writeVersionFile {
+tasks.register('writeVersionFile') {
     doLast {
         def versionFile = file("${buildDir}/version")
         versionFile.parentFile.mkdirs()

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,6 @@ static String findVersionName() {
 }
 
 def releaseStoreFile = file(RELEASE_STORE_FILE, PathValidation.NONE)
-def isCI = System.getenv().containsKey("CI")
 
 // On CI, the files are only created for jobs that really need them, but still need to be
 // able to run unrelated gradle tasks.
@@ -102,14 +101,6 @@ android {
         }
     }
     namespace = 'uk.me.jeremygreen.merging2'
-}
-
-gradleEnterprise {
-    buildScan {
-        uploadInBackground = !isCI
-        termsOfServiceUrl = "https://gradle.com/help/legal-terms-of-use"
-        termsOfServiceAgree = "yes"
-    }
 }
 
 detekt {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,7 +72,7 @@ android {
     buildTypes {
         release {
             if (releaseStoreFile.exists()) {
-                signingConfig signingConfigs.release
+                signingConfig = signingConfigs.release
             }
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
@@ -92,7 +92,7 @@ android {
             dimension "flavour"
         }
     }
-    namespace 'uk.me.jeremygreen.merging2'
+    namespace = 'uk.me.jeremygreen.merging2'
 }
 
 detekt {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,6 +47,14 @@ static String findVersionName() {
 
 def releaseStoreFile = file(RELEASE_STORE_FILE, PathValidation.NONE)
 
+// On CI, the files are only created for jobs that really need them, but still need to be
+// able to run unrelated gradle tasks.
+def fileContentIfExists(path) {
+    return file(path).exists() ?
+         file(path).getText('UTF-8').trim() :
+         null
+}
+
 android {
     compileSdk=36
     defaultConfig {
@@ -64,8 +72,8 @@ android {
     signingConfigs {
         release {
             storeFile releaseStoreFile
-            storePassword file(RELEASE_STORE_PASSWORD_FILE).getText('UTF-8').trim()
-            keyPassword file(RELEASE_KEY_PASSWORD_FILE).getText('UTF-8').trim()
+            storePassword fileContentIfExists(RELEASE_STORE_PASSWORD_FILE)
+            keyPassword fileContentIfExists(RELEASE_KEY_PASSWORD_FILE)
             keyAlias RELEASE_KEY_ALIAS
         }
     }

--- a/app/src/androidTest/kotlin/uk/me/jeremygreen/merging2/AppTest.kt
+++ b/app/src/androidTest/kotlin/uk/me/jeremygreen/merging2/AppTest.kt
@@ -1,0 +1,25 @@
+package uk.me.jeremygreen.merging2
+
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import uk.me.jeremygreen.merging2.splash.SplashActivity
+
+@RunWith(AndroidJUnit4::class)
+class AppTest {
+
+    @get:Rule
+    internal val composeTestRule = createAndroidComposeRule<SplashActivity>()
+
+    @Test
+    fun appLaunches() {
+        composeTestRule
+            .onNode(hasTestTag("topBarTitle"))
+            .assertTextEquals("Merging")
+    }
+
+}

--- a/app/src/main/java/uk/me/jeremygreen/merging2/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/uk/me/jeremygreen/merging2/onboarding/OnboardingActivity.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -70,7 +71,10 @@ internal class OnboardingActivity: AppCompatActivity() {
                         containerColor = MaterialTheme.colorScheme.primaryContainer,
                         titleContentColor = MaterialTheme.colorScheme.primary,
                     ),
-                    title = { Text(text = stringResource(R.string.appName)) }
+                    title = { Text(
+                        text = stringResource(R.string.appName),
+                        Modifier.testTag("topBarTitle"))
+                    }
                 )
             },
             floatingActionButton = {

--- a/bin/waitForAndroidDeviceBoot
+++ b/bin/waitForAndroidDeviceBoot
@@ -49,12 +49,6 @@ while true ; do
 done
 printf "\n"
 
-log "waiting for init.svs.bootanim to change to stopped"
-while [ "$(getprop init.svc.bootanim)" != "stopped" ] ; do
-  waitLoop
-done
-printf "\n"
-
 log "waiting for package manager"
 while ! adb shell pm path android > /dev/null 2>&1 ; do
   waitLoop

--- a/bin/waitForAndroidDeviceBoot
+++ b/bin/waitForAndroidDeviceBoot
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# Copyright (c) 2019-2025 Jeremy Green.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+# shellcheck source=./common.sh
+source "$(dirname "$0")/.common.sh"
+# shellcheck source=../environment
+source "$(dirname "$0")/../environment"
+
+function now() {
+  date +%s
+}
+startTimeSecs=$(now)
+timeoutAtSecs=$((startTimeSecs + 300))
+function timeoutCheck() {
+  if [ "$(now)" -gt "${timeoutAtSecs}" ] ; then
+    log "ERROR: timed out"
+    exit 1
+  fi
+}
+function waitLoop() {
+  timeoutCheck
+  printf "."
+  sleep 5
+}
+
+function getprop() {
+  local name=$1
+  shift
+  adb shell getprop "${name}" 2> /dev/null | tr -d '\r' || true
+}
+
+log "adb wait-for-device"
+adb wait-for-device
+
+log "waiting for boot complete prop"
+while true ; do
+  sysBootCompleted=$(getprop sys.boot_completed)
+  devBootComplete=$(getprop dev.bootcomplete)
+  if [ "${sysBootCompleted}" == "1" ] || [ "${devBootComplete}" == "1" ] ; then
+    break
+  fi
+  waitLoop
+done
+printf "\n"
+
+log "waiting for init.svs.bootanim to change to stopped"
+while [ "$(getprop init.svc.bootanim)" != "stopped" ] ; do
+  waitLoop
+done
+printf "\n"
+
+log "waiting for package manager"
+while ! adb shell pm path android > /dev/null 2>&1 ; do
+  waitLoop
+done
+
+log "emulator ready"

--- a/bin/waitForAndroidDeviceBoot
+++ b/bin/waitForAndroidDeviceBoot
@@ -36,7 +36,7 @@ function getprop() {
 }
 
 log "adb wait-for-device"
-adb wait-for-device
+timeout 300s adb wait-for-device
 
 log "waiting for boot complete prop"
 while true ; do

--- a/detekt.yml
+++ b/detekt.yml
@@ -1,6 +1,8 @@
 complexity:
   ComplexCondition:
     active: false
+  LongMethod:
+    active: false
   TooManyFunctions:
     active: false
 


### PR DESCRIPTION
This PR adds a minimal end-to-end test using AndroidComposeTestRule, and runs it on CI for oldest and newest SDK versions supported by app. Later PRs will add more meaningful tests.

* Circle CI job is based on https://circleci.com/docs/guides/execution-managed/android-machine-image/
* Had to increase Circle CI config version 2.1 to use some new features.
* The PR adds more refined Circle CI caching of the gradle cache. Separate caches for each job, but with fallbacks within and between jobs if precise hits fails.
* The Circle CI android machine image has [not been updated for a long time](https://github.com/jg210/merging/pull/51#issuecomment-3289308936) (longer than the three month period they document and used to follow), so the jobs are having to download android 36 files.
* Chose to increase minSdkVersion since oldest android emulator versions made adb wait-for-device hang. Could have kept it unchanged, but it's still an old android version and don't really want to make something that'd be untested.
* Had to take care with which file pass from build job to androidTest jobs, otherwise gradle was rebuilding the app.

# End-to-end testing framework choices

## espresso 

* Only for View-based UI.

## UI automator 2
    
* Might be needed for interaction with camera app?
* Might be able to combine with compose test API / espresso? I.e. be able to use it but only if/where necessary?

## Appium

* Uses the other technologies underneath.  There's no reason to use it here. It'd be more use if wanted to test cross-platform app (android and iOS).

## AndroidComposeTestRule

* https://developer.android.com/jetpack/compose/testing
* https://developer.android.com/develop/ui/compose/testing
* OK for a single-Activity app
* Multiple Activity app harder. Could use ActivityScenario or espresso too, but likely easier to migrate to single Activity app? Something that's worth doing anyway, since it's not 2007 any more.
